### PR TITLE
fix: declare contracts.tools to silence v2026.5.x registerTool warnings

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,24 @@
 {
   "id": "openclaw-basic-memory",
   "kind": "memory",
+  "contracts": {
+    "tools": [
+      "build_context",
+      "delete_note",
+      "edit_note",
+      "list_memory_projects",
+      "list_workspaces",
+      "memory_get",
+      "memory_search",
+      "move_note",
+      "read_note",
+      "schema_diff",
+      "schema_infer",
+      "schema_validate",
+      "search_notes",
+      "write_note"
+    ]
+  },
   "skills": [
     "skills/memory-defrag",
     "skills/memory-ingest",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@sinclair/typebox": "0.34.47"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.7"
+    "openclaw": ">=2026.5.2"
   },
   "scripts": {
     "postinstall": "bash scripts/setup-bm.sh || true",


### PR DESCRIPTION
## Summary
- Adds `contracts.tools` to `openclaw.plugin.json` listing all 14 agent tools the plugin registers via `api.registerTool(...)`, so OpenClaw v2026.5.x's descriptor-first planner can narrow plugin loading without importing the runtime
- Bumps `peerDependencies.openclaw` from `>=2026.3.7` to `>=2026.5.2` to track the version that introduced the enforcement warning

Fixes the cosmetic but noisy warning fired once per `registerTool` call at gateway boot:
```
plugin must declare contracts.tools before registering agent tools (plugin=openclaw-basic-memory, ...)
```

Pattern matches reference plugins bundled with OpenClaw (`tavily`, `firecrawl`, `file-transfer`, `xai`), which all declare every tool name they register statically — `contracts.tools` is a static ownership snapshot, not a runtime-conditional list. Field is documented in `openclaw/docs/plugins/manifest.md` (lines 481–523 of v2026.4.29).

Skipped the optional `toolMetadata` perf optimization called out in the issue — it doesn't silence the warning and adds maintenance overhead duplicating descriptions already on the runtime tools.

Closes #40

## Test plan
- [ ] Install with `openclaw@2026.5.2` and confirm `~/.openclaw/logs/gateway.err.log` no longer emits the `must declare contracts.tools` warnings at startup
- [ ] Verify all 14 tools still register and function (search/read/write/edit/context/delete/move + list/schema + memory_search/memory_get)
- [ ] `bun run check-types` and `bun run lint` pass
- [ ] `bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)