### PR TITLE
fix: metadata_filters parameter dropped from search_notes schema

### DIFF
--- a/tools/search-notes.ts
+++ b/tools/search-notes.ts
@@ -26,10 +26,14 @@ export function registerSearchTool(
           }),
         ),
         metadata_filters: Type.Optional(
-          Type.Record(Type.String(), Type.Unknown(), {
-            description:
-              "Filter by frontmatter fields. Supports equality, $in, $gt/$gte/$lt/$lte, $between, and array-contains operators.",
-          }),
+          Type.Object(
+            {},
+            {
+              additionalProperties: true,
+              description:
+                "Filter by frontmatter fields. Supports equality, $in, $gt/$gte/$lt/$lte, $between, and array-contains operators.",
+            },
+          ),
         ),
         tags: Type.Optional(
           Type.Array(Type.String(), {


### PR DESCRIPTION
## Summary
- Replace `Type.Record(Type.String(), Type.Unknown())` with `Type.Object({}, { additionalProperties: true })` in `search_notes` so `metadata_filters` survives provider schema sanitizers.
- The `Type.Record` form emitted `patternProperties: { "^(.*)$": {} }`, which Gemini's compat path strips and OpenAI strict-tools mode rejects. Net result: the parameter disappeared from the model-facing schema for some agents (e.g. github-copilot/gpt-5.4).
- Runtime behavior and TypeScript types unchanged — the handler already casts to `Record<string, unknown>`.

Fixes #38

## Test plan
- [x] `bun run check-types` clean
- [x] `bun test` — 225 pass / 0 fail
- [x] Verified rendered JSON Schema contains `additionalProperties: true` and no `patternProperties`
- [ ] Spot-check `metadata_filters` is visible to a github-copilot agent after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)