### PR TITLE
[codex] Align OpenClaw 2026.5 plugin packaging

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,7 @@ Clone and link locally for plugin development:
 git clone https://github.com/basicmachines-co/openclaw-basic-memory.git
 cd openclaw-basic-memory
 bun install
+bun run fetch-skills
 openclaw plugins install -l "$PWD"
 openclaw plugins enable openclaw-basic-memory --slot memory
 openclaw gateway restart
@@ -37,8 +38,9 @@ Or load directly from a path in your OpenClaw config:
 
 ```bash
 bun run check-types   # Type checking
+bun run build         # Compile package runtime to dist/
 bun run lint          # Linting
-bun test              # Run tests (156 tests)
+bun test              # Run tests
 bun run test:int      # Real BM MCP integration tests
 ```
 
@@ -64,7 +66,7 @@ BASIC_MEMORY_REPO=/absolute/path/to/basic-memory bun run test:int
 This package is published as `@basicmemory/openclaw-basic-memory`.
 
 ```bash
-# Verify release readiness (types + tests + npm pack dry run)
+# Verify release readiness (types + build + tests + npm pack dry run)
 just release-check
 
 # Inspect publish payload

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then install the plugin:
 
 ```bash
 openclaw plugins install @basicmemory/openclaw-basic-memory
+openclaw plugins enable openclaw-basic-memory --slot memory
 openclaw gateway restart
 ```
 
@@ -54,7 +55,8 @@ Verify:
 
 ```bash
 openclaw plugins list
-openclaw plugins info openclaw-basic-memory
+openclaw plugins inspect openclaw-basic-memory --json
+openclaw plugins doctor
 ```
 
 ## Configuration
@@ -63,8 +65,15 @@ openclaw plugins info openclaw-basic-memory
 
 ```json5
 {
-  "openclaw-basic-memory": {
-    enabled: true
+  plugins: {
+    entries: {
+      "openclaw-basic-memory": {
+        enabled: true
+      }
+    },
+    slots: {
+      memory: "openclaw-basic-memory"
+    }
   }
 }
 ```
@@ -75,16 +84,23 @@ This uses sensible defaults: auto-generated project name, maps to your workspace
 
 ```json5
 {
-  "openclaw-basic-memory": {
-    enabled: true,
-    config: {
-      project: "my-agent",        // BM project name (default: "openclaw-{hostname}")
-      projectPath: ".",            // Project directory (default: workspace root)
-      memoryDir: "memory/",        // Where task notes live
-      memoryFile: "MEMORY.md",     // Working memory file
-      autoCapture: true,           // Record conversations as daily notes
-      autoRecall: true,            // Inject active tasks + recent activity at session start
-      debug: false                 // Verbose logging
+  plugins: {
+    entries: {
+      "openclaw-basic-memory": {
+        enabled: true,
+        config: {
+          project: "my-agent",        // BM project name (default: "openclaw-{hostname}")
+          projectPath: ".",            // Project directory (default: workspace root)
+          memoryDir: "memory/",        // Where task notes live
+          memoryFile: "MEMORY.md",     // Working memory file
+          autoCapture: true,           // Record conversations as daily notes
+          autoRecall: true,            // Inject active tasks + recent activity at session start
+          debug: false                 // Verbose logging
+        }
+      }
+    },
+    slots: {
+      memory: "openclaw-basic-memory"
     }
   }
 }
@@ -172,19 +188,23 @@ openclaw basic-memory status
 
 ## Bundled skills
 
-Six skills ship with the plugin — no installation needed:
+Ten skills ship with the plugin — no installation needed:
 
-- **memory-tasks** — structured task tracking that survives context compaction
-- **memory-reflect** — periodic consolidation of recent notes into durable memory
 - **memory-defrag** — cleanup and reorganization of memory files
-- **memory-schema** — schema lifecycle (infer, create, validate, diff)
+- **memory-ingest** — import existing material into Basic Memory
+- **memory-lifecycle** — manage note/project lifecycle workflows
+- **memory-literary-analysis** — analyze texts and reading notes
 - **memory-metadata-search** — query notes by frontmatter fields
 - **memory-notes** — guidance for writing well-structured notes
+- **memory-reflect** — periodic consolidation of recent notes into durable memory
+- **memory-research** — research synthesis into durable notes
+- **memory-schema** — schema lifecycle (infer, create, validate, diff)
+- **memory-tasks** — structured task tracking that survives context compaction
 
 ### Updating skills
 
 ```bash
-npx skills add basicmachines-co/basic-memory-skills --agent openclaw
+bun run fetch-skills
 ```
 
 ## Task notes

--- a/commands/cli.ts
+++ b/commands/cli.ts
@@ -1,4 +1,4 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import type { BasicMemoryConfig } from "../config.ts"
 import { log } from "../logger.ts"

--- a/commands/skills.test.ts
+++ b/commands/skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import { registerSkillCommands } from "./skills.ts"
 
 describe("skill slash commands", () => {

--- a/commands/skills.ts
+++ b/commands/skills.ts
@@ -1,11 +1,9 @@
-import { readFileSync } from "node:fs"
+import { existsSync, readFileSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const SKILLS_DIR = resolve(__dirname, "..", "skills")
-const MANIFEST_PATH = resolve(SKILLS_DIR, "manifest.json")
 
 interface ManifestEntry {
   dir: string
@@ -13,9 +11,22 @@ interface ManifestEntry {
   description: string
 }
 
-function loadManifest(): ManifestEntry[] {
+function resolveSkillsDir(api: OpenClawPluginApi): string {
+  if (api.resolvePath) {
+    return api.resolvePath("skills")
+  }
+
+  const sourceRootSkills = resolve(__dirname, "..", "skills")
+  if (existsSync(sourceRootSkills)) {
+    return sourceRootSkills
+  }
+
+  return resolve(__dirname, "..", "..", "skills")
+}
+
+function loadManifest(skillsDir: string): ManifestEntry[] {
   try {
-    const raw = readFileSync(MANIFEST_PATH, "utf-8")
+    const raw = readFileSync(resolve(skillsDir, "manifest.json"), "utf-8")
     return JSON.parse(raw) as ManifestEntry[]
   } catch {
     throw new Error(
@@ -24,16 +35,17 @@ function loadManifest(): ManifestEntry[] {
   }
 }
 
-function loadSkill(dir: string): string {
-  return readFileSync(resolve(SKILLS_DIR, dir, "SKILL.md"), "utf-8")
+function loadSkill(skillsDir: string, dir: string): string {
+  return readFileSync(resolve(skillsDir, dir, "SKILL.md"), "utf-8")
 }
 
 export function registerSkillCommands(api: OpenClawPluginApi): void {
-  const manifest = loadManifest()
+  const skillsDir = resolveSkillsDir(api)
+  const manifest = loadManifest(skillsDir)
 
   for (const entry of manifest) {
     const commandName = entry.dir.replace(/^memory-/, "")
-    const content = loadSkill(entry.dir)
+    const content = loadSkill(skillsDir, entry.dir)
 
     api.registerCommand({
       name: commandName,

--- a/commands/slash.ts
+++ b/commands/slash.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 
@@ -16,7 +16,9 @@ export function registerCommands(
     description: "Install or update the Basic Memory CLI (requires uv)",
     requireAuth: true,
     handler: async () => {
-      const scriptPath = resolve(__dirname, "..", "scripts", "setup-bm.sh")
+      const scriptPath = api.resolvePath
+        ? api.resolvePath("scripts/setup-bm.sh")
+        : resolve(__dirname, "..", "scripts", "setup-bm.sh")
       log.info(`/bm-setup: running ${scriptPath}`)
 
       try {

--- a/config.test.ts
+++ b/config.test.ts
@@ -147,6 +147,18 @@ describe("config", () => {
       expect(parseConfig({ cloud: null }).cloud).toBeUndefined()
     })
 
+    it("should throw error for unknown cloud config keys", () => {
+      expect(() =>
+        parseConfig({
+          cloud: {
+            url: "https://cloud.basicmemory.com",
+            api_key: "test-key",
+            extra: true,
+          },
+        }),
+      ).toThrow("basic-memory cloud config has unknown keys: extra")
+    })
+
     it("should throw error for unknown config keys", () => {
       expect(() => parseConfig({ unknownKey: "value" })).toThrow(
         "basic-memory config has unknown keys: unknownKey",

--- a/config.ts
+++ b/config.ts
@@ -101,6 +101,7 @@ export function parseConfig(raw: unknown): BasicMemoryConfig {
   let cloud: CloudConfig | undefined
   if (cfg.cloud && typeof cfg.cloud === "object" && !Array.isArray(cfg.cloud)) {
     const c = cfg.cloud as Record<string, unknown>
+    assertAllowedKeys(c, ["url", "api_key"], "basic-memory cloud config")
     if (typeof c.url === "string" && typeof c.api_key === "string") {
       cloud = { url: c.url, api_key: c.api_key }
     }

--- a/context-engine/basic-memory-context-engine.ts
+++ b/context-engine/basic-memory-context-engine.ts
@@ -1,24 +1,51 @@
-import { createRequire } from "node:module"
-import { dirname, resolve } from "node:path"
-import { pathToFileURL } from "node:url"
 import type { AgentMessage } from "@mariozechner/pi-agent-core"
-import type {
-  AssembleResult,
-  BootstrapResult,
-  CompactResult,
-  ContextEngine,
-} from "openclaw/plugin-sdk"
+import { delegateCompactionToRuntime } from "openclaw/plugin-sdk/core"
 import type { BmClient } from "../bm-client.ts"
 import type { BasicMemoryConfig } from "../config.ts"
 import { selectCaptureTurn } from "../hooks/capture.ts"
 import { loadRecallState } from "../hooks/recall.ts"
 import { log } from "../logger.ts"
 
-const require = createRequire(import.meta.url)
 export const MAX_ASSEMBLE_RECALL_CHARS = 1200
 const TRUNCATED_RECALL_SUFFIX = "\n\n[Basic Memory recall truncated]"
 const SUBAGENT_HANDOFF_FOLDER = "agent/subagents"
 const MAX_SUBAGENT_RECALL_CHARS = 800
+
+type AssembleResult = {
+  messages: AgentMessage[]
+  estimatedTokens: number
+  systemPromptAddition?: string
+}
+
+type BootstrapResult = {
+  bootstrapped: boolean
+  importedMessages?: number
+  reason?: string
+}
+
+type CompactResult = {
+  ok: boolean
+  compacted: boolean
+  reason?: string
+  result?: {
+    summary?: string
+    firstKeptEntryId?: string
+    tokensBefore: number
+    tokensAfter?: number
+    details?: unknown
+    sessionId?: string
+    sessionFile?: string
+  }
+}
+
+interface ContextEngine {
+  readonly info: {
+    id: string
+    name: string
+    version?: string
+    ownsCompaction?: boolean
+  }
+}
 
 interface SessionMemoryState {
   recallContext: string
@@ -104,36 +131,6 @@ function buildSubagentCompletionUpdate(params: {
   ].join("\n")
 }
 
-type LegacyContextEngineModule = {
-  LegacyContextEngine: new () => {
-    compact(params: {
-      sessionId: string
-      sessionFile: string
-      tokenBudget?: number
-      force?: boolean
-      currentTokenCount?: number
-      compactionTarget?: "budget" | "threshold"
-      customInstructions?: string
-      runtimeContext?: Record<string, unknown>
-    }): Promise<CompactResult>
-  }
-}
-
-async function loadLegacyContextEngine(): Promise<
-  LegacyContextEngineModule["LegacyContextEngine"]
-> {
-  const pluginSdkPath = require.resolve("openclaw/plugin-sdk")
-  const legacyPath = resolve(
-    dirname(pluginSdkPath),
-    "context-engine",
-    "legacy.js",
-  )
-  const module = (await import(
-    pathToFileURL(legacyPath).href
-  )) as LegacyContextEngineModule
-  return module.LegacyContextEngine
-}
-
 export class BasicMemoryContextEngine implements ContextEngine {
   readonly info = {
     id: "openclaw-basic-memory",
@@ -144,9 +141,6 @@ export class BasicMemoryContextEngine implements ContextEngine {
 
   private readonly sessionState = new Map<string, SessionMemoryState>()
   private readonly subagentState = new Map<string, SubagentHandoffState>()
-  private legacyContextEnginePromise: Promise<
-    InstanceType<LegacyContextEngineModule["LegacyContextEngine"]>
-  > | null = null
 
   constructor(
     private readonly client: BmClient,
@@ -243,8 +237,7 @@ export class BasicMemoryContextEngine implements ContextEngine {
     customInstructions?: string
     runtimeContext?: Record<string, unknown>
   }): Promise<CompactResult> {
-    const legacy = await this.getLegacyContextEngine()
-    return legacy.compact(params)
+    return delegateCompactionToRuntime(params)
   }
 
   async prepareSubagentSpawn(params: {
@@ -314,17 +307,5 @@ export class BasicMemoryContextEngine implements ContextEngine {
   async dispose(): Promise<void> {
     this.sessionState.clear()
     this.subagentState.clear()
-  }
-
-  private async getLegacyContextEngine(): Promise<
-    InstanceType<LegacyContextEngineModule["LegacyContextEngine"]>
-  > {
-    if (!this.legacyContextEnginePromise) {
-      this.legacyContextEnginePromise = loadLegacyContextEngine().then(
-        (LegacyContextEngine) => new LegacyContextEngine(),
-      )
-    }
-
-    return this.legacyContextEnginePromise
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process"
 
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry"
 import { BmClient } from "./bm-client.ts"
 import { registerCli } from "./commands/cli.ts"
 import { registerSkillCommands } from "./commands/skills.ts"
@@ -33,15 +33,14 @@ import { registerWriteTool } from "./tools/write-note.ts"
 
 const BASIC_MEMORY_RELEASE_TAG = "v0.20.2"
 
-export default {
+export default definePluginEntry({
   id: "openclaw-basic-memory",
   name: "Basic Memory",
   description:
     "Local-first knowledge graph for OpenClaw — persistent memory with graph search and composited memory_search",
-  kind: "memory" as const,
   configSchema: basicMemoryConfigSchema,
 
-  register(api: OpenClawPluginApi) {
+  register(api) {
     const cfg = parseConfig(api.pluginConfig)
 
     initLogger(api.logger, cfg.debug)
@@ -159,4 +158,4 @@ export default {
       },
     })
   },
-}
+})

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -23,6 +23,7 @@
     "skills/memory-defrag",
     "skills/memory-ingest",
     "skills/memory-lifecycle",
+    "skills/memory-literary-analysis",
     "skills/memory-metadata-search",
     "skills/memory-notes",
     "skills/memory-reflect",
@@ -52,15 +53,25 @@
       "help": "Path to the basic-memory CLI binary (default: 'bm')",
       "advanced": true
     },
-    "indexInterval": {
-      "label": "Index Interval (seconds)",
-      "placeholder": "300",
-      "help": "Seconds between periodic re-indexing sweeps",
-      "advanced": true
-    },
     "autoCapture": {
       "label": "Auto-Capture",
       "help": "Automatically index conversation content after each turn"
+    },
+    "captureMinChars": {
+      "label": "Capture Min Characters",
+      "placeholder": "10",
+      "help": "Minimum user/assistant text length before auto-capture indexes a turn",
+      "advanced": true
+    },
+    "autoRecall": {
+      "label": "Auto-Recall",
+      "help": "Automatically load relevant Basic Memory context when a session starts"
+    },
+    "recallPrompt": {
+      "label": "Recall Prompt",
+      "placeholder": "Check for active tasks and recent activity...",
+      "help": "Prompt used to gather initial Basic Memory context",
+      "advanced": true
     },
     "debug": {
       "label": "Debug Logging",
@@ -85,18 +96,27 @@
     "properties": {
       "project": { "type": "string" },
       "memoryDir": { "type": "string" },
+      "memory_dir": { "type": "string" },
       "memoryFile": { "type": "string" },
+      "memory_file": { "type": "string" },
       "bmPath": { "type": "string" },
-      "indexInterval": { "type": "number", "minimum": 30, "maximum": 3600 },
       "autoCapture": { "type": "boolean" },
+      "captureMinChars": { "type": "number", "minimum": 0 },
+      "capture_min_chars": { "type": "number", "minimum": 0 },
+      "autoRecall": { "type": "boolean" },
+      "auto_recall": { "type": "boolean" },
+      "recallPrompt": { "type": "string" },
+      "recall_prompt": { "type": "string" },
       "debug": { "type": "boolean" },
       "projectPath": { "type": "string" },
       "cloud": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "url": { "type": "string" },
           "api_key": { "type": "string" }
-        }
+        },
+        "required": ["url", "api_key"]
       }
     },
     "required": []

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "@basicmemory/openclaw-basic-memory",
   "version": "0.2.3",
   "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "description": "Basic Memory plugin for OpenClaw — local-first knowledge graph for agent memory",
   "license": "MIT",
   "repository": {
@@ -11,7 +13,7 @@
   "files": [
     "index.ts",
     "bm-client.ts",
-    "context-engine/",
+    "context-engine/basic-memory-context-engine.ts",
     "config.ts",
     "logger.ts",
     "commands/cli.ts",
@@ -35,6 +37,7 @@
     "schema/task-schema.ts",
     "schema/conversation-schema.ts",
     "skills/",
+    "dist/",
     "scripts/fetch-skills.ts",
     "scripts/setup-bm.sh",
     "openclaw.plugin.json",
@@ -53,25 +56,40 @@
   },
   "scripts": {
     "postinstall": "bash scripts/setup-bm.sh || true",
+    "build": "tsc -p tsconfig.build.json",
     "check-types": "tsc --noEmit",
     "lint": "bunx @biomejs/biome ci .",
     "lint:fix": "bunx @biomejs/biome check --write .",
     "fetch-skills": "bun scripts/fetch-skills.ts",
-    "prepack": "bun scripts/fetch-skills.ts",
+    "prepack": "bun run fetch-skills && bun run build",
     "test": "bun test",
     "test:int": "BM_INTEGRATION=1 BM_BIN=${BM_BIN:-./scripts/bm-local.sh} bun test integration --timeout 120000",
     "test:coverage": "bun test --coverage",
-    "release:check": "bun run check-types && bun test && npm pack --dry-run"
+    "release:check": "bun run check-types && bun run build && bun test && npm pack --dry-run"
   },
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.5.2",
+      "minGatewayVersion": "2026.5.2"
+    },
+    "build": {
+      "openclawVersion": "2026.5.4",
+      "pluginSdkVersion": "2026.5.4"
+    },
+    "install": {
+      "minHostVersion": ">=2026.5.2"
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",
     "@types/node": "^20.0.0",
-    "openclaw": "^2026.3.8",
+    "openclaw": "^2026.5.4",
     "typescript": "^5.9.3"
   }
 }

--- a/tools/build-context.test.ts
+++ b/tools/build-context.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerContextTool } from "./build-context.ts"
 

--- a/tools/build-context.ts
+++ b/tools/build-context.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/delete-note.ts
+++ b/tools/delete-note.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/edit-note.test.ts
+++ b/tools/edit-note.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerEditTool } from "./edit-note.ts"
 

--- a/tools/edit-note.ts
+++ b/tools/edit-note.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/list-memory-projects.test.ts
+++ b/tools/list-memory-projects.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerProjectListTool } from "./list-memory-projects.ts"
 

--- a/tools/list-memory-projects.ts
+++ b/tools/list-memory-projects.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient, ProjectListResult } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/list-workspaces.test.ts
+++ b/tools/list-workspaces.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerWorkspaceListTool } from "./list-workspaces.ts"
 

--- a/tools/list-workspaces.ts
+++ b/tools/list-workspaces.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient, WorkspaceResult } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/memory-provider.test.ts
+++ b/tools/memory-provider.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import type { BasicMemoryConfig } from "../config.ts"
 import { registerMemoryProvider, setWorkspaceDir } from "./memory-provider.ts"

--- a/tools/memory-provider.ts
+++ b/tools/memory-provider.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import type { BasicMemoryConfig } from "../config.ts"
 import { log } from "../logger.ts"

--- a/tools/move-note.ts
+++ b/tools/move-note.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/read-note.test.ts
+++ b/tools/read-note.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerReadTool } from "./read-note.ts"
 

--- a/tools/read-note.ts
+++ b/tools/read-note.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/schema-diff.test.ts
+++ b/tools/schema-diff.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerSchemaDiffTool } from "./schema-diff.ts"
 

--- a/tools/schema-diff.ts
+++ b/tools/schema-diff.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/schema-infer.test.ts
+++ b/tools/schema-infer.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerSchemaInferTool } from "./schema-infer.ts"
 

--- a/tools/schema-infer.ts
+++ b/tools/schema-infer.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/schema-validate.test.ts
+++ b/tools/schema-validate.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerSchemaValidateTool } from "./schema-validate.ts"
 

--- a/tools/schema-validate.ts
+++ b/tools/schema-validate.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/search-notes.test.ts
+++ b/tools/search-notes.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { registerSearchTool } from "./search-notes.ts"
 

--- a/tools/search-notes.ts
+++ b/tools/search-notes.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { log } from "../logger.ts"
 

--- a/tools/write-note.test.ts
+++ b/tools/write-note.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "bun:test"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { NoteAlreadyExistsError } from "../bm-client.ts"
 import { registerWriteTool } from "./write-note.ts"

--- a/tools/write-note.ts
+++ b/tools/write-note.ts
@@ -1,5 +1,5 @@
 import { Type } from "@sinclair/typebox"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry"
 import type { BmClient } from "../bm-client.ts"
 import { NoteAlreadyExistsError } from "../bm-client.ts"
 import { log } from "../logger.ts"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "rewriteRelativeImportExtensions": true,
+    "sourceMap": false
+  }
+}


### PR DESCRIPTION
## Summary

Addresses #43 by bringing the plugin closer to OpenClaw 2026.5.x's native plugin expectations:

- add a compiled `dist` runtime build and `openclaw.runtimeExtensions` package metadata
- switch the plugin entry to `definePluginEntry(...)`
- replace deprecated root `openclaw/plugin-sdk` imports with focused subpath imports
- use OpenClaw's public compaction delegation helper instead of resolving internal legacy context-engine files
- align `openclaw.plugin.json` config schema with `parseConfig(...)`, including snake_case aliases and strict cloud config validation
- fix compiled-runtime path resolution for bundled skills and `/bm-setup`
- update docs for `plugins.slots.memory`, inspect/doctor verification, build checks, and the current skill set

## Validation

- `npm run check-types`
- `npm test` — 226 passing
- `npm run lint` — passes; Biome reports an informational schema-version mismatch because installed Biome is 2.4.14 while `biome.json` references 2.4.6
- `npm run build`
- `npm pack --dry-run --ignore-scripts --cache /private/tmp/openclaw-basic-memory-npm-cache` — verified `dist/index.js` and skills are included
- `node -e "import('./dist/index.js').then((m)=>{ if (!m.default?.register) throw new Error('missing plugin register'); console.log(m.default.id) })"`
- local contracts audit confirmed manifest `contracts.tools` exactly matches the 14 registered tools

## Notes

I used `npm run fetch-skills` locally because `skills/` is intentionally ignored and required for tests/pack validation. Generated `dist/`, `skills/`, and `node_modules/` remain ignored and are not committed.